### PR TITLE
Add 'requirements.txt' for MkDocs and GH Pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: GitHub Pages
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [master]
+#  pull_request:
+#    branches: [master]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/setup-python@v2.1.3
       - name: Run a multi-line script
         run: |
+          git config --global user.name "GitHub Pages - Auto Deploy"
+          git config --global user.email "noreply@ust-quantil.github.io"
           python3 -m venv venv
           source venv/bin/activate
           pip3 install -r requirements.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,4 +16,4 @@ jobs:
           python3 -m venv venv
           source venv/bin/activate
           pip3 install -r requirements.txt
-          mkdocs gh-deploy
+          mkdocs gh-deploy --force

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,10 @@ jobs:
         uses: actions/setup-python@v2.1.3
       - name: Run a multi-line script
         run: |
-          git config --global user.name "GitHub Pages - Auto Deploy"
-          git config --global user.email "noreply@ust-quantil.github.io"
+          #git config --global user.name "GitHub Pages - Auto Deploy"
+          #git config --global user.email "noreply@ust-quantil.github.io"
           python3 -m venv venv
           source venv/bin/activate
           pip3 install -r requirements.txt
-          mkdocs gh-deploy --force
+      - name: Deploy MkDocs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@1.15

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run a multi-line script
         run: |
-          python -m venv venv
+          python3 -m venv venv
           source venv/bin/activate
-          pip install -r requirements.txt
+          pip3 install -r requirements.txt
           mkdocs build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2.1.3
       - name: Run a multi-line script
         run: |
           python3 -m venv venv
           source venv/bin/activate
           pip3 install -r requirements.txt
-          mkdocs build
+          mkdocs gh-deploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v
+      - uses: actions/checkout@v2
       - name: Run a multi-line script
         run: |
           python -m venv venv

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,9 @@ jobs:
         uses: actions/setup-python@v2.1.3
       - name: Run a multi-line script
         run: |
-          #git config --global user.name "GitHub Pages - Auto Deploy"
-          #git config --global user.email "noreply@ust-quantil.github.io"
+          git config --global user.name "GitHub Pages - Auto Deploy"
+          git config --global user.email "noreply@ust-quantil.github.io"
           python3 -m venv venv
           source venv/bin/activate
           pip3 install -r requirements.txt
-      - name: Deploy MkDocs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@1.15
+          mkdocs gh-deploy --force

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: GitHub Pages
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [master]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v
+      - name: Run a multi-line script
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+          mkdocs build

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+venv/
 
 # C extensions
 *.so

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+click==7.1.2
+future==0.18.2
+Jinja2==2.11.2
+joblib==0.17.0
+livereload==2.6.3
+lunr==0.5.8
+Markdown==3.3
+MarkupSafe==1.1.1
+mkdocs==1.1.2
+nltk==3.5
+PyYAML==5.3.1
+regex==2020.10.11
+six==1.15.0
+tornado==6.0.4
+tqdm==4.50.2


### PR DESCRIPTION
With this PR pushes to the `master` branch will be deployed using GH pages on the following URL:
https://ust-quantil.github.io/quantil-docs/

I will also try to get the latest version of MkDocs to work with RtD, however for this, this must go on master...